### PR TITLE
feat: allow to define attributes for the links

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -186,7 +186,7 @@ return [
 
     'max_nesting_level' => INF,
 
-    'link_attributes'            => ['class' => 'font-semibold link'],
+    'link_attributes'            => [],
     'link_renderer_view'            => 'ark::external-link',
     'link_renderer_view_attributes' => [
         'inline' => true,

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -186,6 +186,7 @@ return [
 
     'max_nesting_level' => INF,
 
+    'link_attributes'            => ['class' => 'font-semibold link'],
     'link_renderer_view'            => 'ark::external-link',
     'link_renderer_view_attributes' => [
         'inline' => true,

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -186,7 +186,7 @@ return [
 
     'max_nesting_level' => INF,
 
-    'link_attributes'            => ['class' => 'font-semibold link'],
+    'link_attributes'               => ['class' => 'font-semibold link'],
     'link_renderer_view'            => 'ark::external-link',
     'link_renderer_view_attributes' => [
         'inline' => true,

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -186,7 +186,7 @@ return [
 
     'max_nesting_level' => INF,
 
-    'link_attributes'            => [],
+    'link_attributes'               => [],
     'link_renderer_view'            => 'ark::external-link',
     'link_renderer_view_attributes' => [
         'inline' => true,

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -186,7 +186,7 @@ return [
 
     'max_nesting_level' => INF,
 
-    'link_attributes'               => ['class' => 'font-semibold link'],
+    'link_attributes'               => [],
     'link_renderer_view'            => 'ark::external-link',
     'link_renderer_view_attributes' => [
         'inline' => true,

--- a/src/Extensions/Highlighter/CodeBlockHighlighter.php
+++ b/src/Extensions/Highlighter/CodeBlockHighlighter.php
@@ -8,7 +8,7 @@ class CodeBlockHighlighter
 {
     public function highlight(string $codeBlock, ?string $language = null)
     {
-        if (str_contains($codeBlock, "<")) {
+        if (str_contains($codeBlock, '<')) {
             preg_match('#<\s*?code\b[^>]*>(.*?)</code\b[^>]*>#s', $codeBlock, $matches);
 
             $codeBlock = $matches[1];

--- a/src/Extensions/Link/LinkRenderer.php
+++ b/src/Extensions/Link/LinkRenderer.php
@@ -47,7 +47,7 @@ final class LinkRenderer implements InlineRendererInterface, ConfigurationAwareI
         }
 
         if ($this->isInternalLink($attrs['href'])) {
-            $attrs = array_merge($attrs, config('markdown.link_attributes'));
+            $attrs = array_merge($attrs, config('markdown.link_attributes', []));
 
             return new HtmlElement('a', $attrs, $htmlRenderer->renderInlines($inline->children()));
         }

--- a/src/Extensions/Link/LinkRenderer.php
+++ b/src/Extensions/Link/LinkRenderer.php
@@ -48,6 +48,7 @@ final class LinkRenderer implements InlineRendererInterface, ConfigurationAwareI
 
         if ($this->isInternalLink($attrs['href'])) {
             $attrs = array_merge($attrs, config('markdown.link_attributes'));
+
             return new HtmlElement('a', $attrs, $htmlRenderer->renderInlines($inline->children()));
         }
 

--- a/src/Extensions/Link/LinkRenderer.php
+++ b/src/Extensions/Link/LinkRenderer.php
@@ -47,6 +47,7 @@ final class LinkRenderer implements InlineRendererInterface, ConfigurationAwareI
         }
 
         if ($this->isInternalLink($attrs['href'])) {
+            $attrs = array_merge($attrs, config('markdown.link_attributes'));
             return new HtmlElement('a', $attrs, $htmlRenderer->renderInlines($inline->children()));
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a new setting for the commonmark package to define custom attributes on the "regular" links (not external). Used on msq to define the classes the link will have.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
