### PR TITLE
fix: handle case twitter url is invalid or twitter is down

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "pestphp/pest-plugin-livewire": "^1.0.0",
         "phpunit/phpunit": "^9.5",
         "orchestra/testbench": "^6.2",
-        "spatie/pest-plugin-snapshots": "^1.0"
+        "spatie/pest-plugin-snapshots": "^1.0",
+        "guzzlehttp/guzzle": "^7.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f063e8b6901b590ad0bb3a00533e7449",
+    "content-hash": "da0c52faec8610b66bd0d5589d4ba2f5",
     "packages": [
         {
             "name": "arkecosystem/ui",
@@ -6217,6 +6217,164 @@
             "time": "2020-10-07T15:56:32+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
             "name": "guzzlehttp/psr7",
             "version": "1.7.0",
             "source": {
@@ -8488,6 +8646,58 @@
                 }
             ],
             "time": "2021-02-02T14:45:58+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-message",
@@ -10914,5 +11124,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Extensions/Image/TwitterRenderer.php
+++ b/src/Extensions/Image/TwitterRenderer.php
@@ -36,6 +36,7 @@ final class TwitterRenderer
         // cached forever. We'll cache the result for 5 minutes.
         if ($result === false) {
             Cache::forget(md5($url));
+
             return Cache::remember(md5($url), now()->addSeconds(15), fn () => '');
         }
 

--- a/src/Extensions/Image/TwitterRenderer.php
+++ b/src/Extensions/Image/TwitterRenderer.php
@@ -36,6 +36,7 @@ final class TwitterRenderer
         // cached forever. We'll cache the result for 5 minutes.
         if ($result === false) {
             Cache::forget(md5($url));
+
             return Cache::remember(md5($url), now()->addSeconds(15), fn () => 'cached !5 mintes');
         }
 

--- a/src/Extensions/Image/TwitterRenderer.php
+++ b/src/Extensions/Image/TwitterRenderer.php
@@ -36,7 +36,7 @@ final class TwitterRenderer
         // cached forever. We'll cache the result for 5 minutes.
         if ($result === false) {
             Cache::forget(md5($url));
-            return Cache::remember(md5($url), now()->addSeconds(15), fn () => '');
+            return Cache::remember(md5($url), now()->addMinutes(5), fn () => '');
         }
 
         return $result;

--- a/src/Extensions/Image/TwitterRenderer.php
+++ b/src/Extensions/Image/TwitterRenderer.php
@@ -2,6 +2,8 @@
 
 namespace ARKEcosystem\CommonMark\Extensions\Image;
 
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -11,14 +13,32 @@ final class TwitterRenderer
     {
         $url = 'https://twitter.com/'.$url->getId();
 
-        return Cache::rememberForever(md5($url), fn () => Http::get('https://publish.twitter.com/oembed', [
-            'url'         => $url,
-            'hide_thread' => 1,
-            'hide_media'  => 0,
-            'omit_script' => true,
-            'dnt'         => true,
-            'limit'       => 20,
-            'chrome'      => 'nofooter',
-        ])->json()['html']);
+        $result = Cache::rememberForever(md5($url), function () use ($url) {
+            try {
+                $response = Http::get('https://publish.twitter.com/oembed', [
+                    'url'         => $url,
+                    'hide_thread' => 1,
+                    'hide_media'  => 0,
+                    'omit_script' => true,
+                    'dnt'         => true,
+                    'limit'       => 20,
+                    'chrome'      => 'nofooter',
+                ])->json();
+
+                return Arr::get($response, 'html', '');
+            } catch (ConnectionException $e) {
+                return false;
+            }
+        });
+
+        // If the result is `false`, means we had a connection error
+        // (publish.twitter.com is down) in that case the results should not be
+        // cached forever. We'll cache the result for 5 minutes.
+        if ($result === false) {
+            Cache::forget(md5($url));
+            return Cache::remember(md5($url), now()->addSeconds(15), fn () => 'cached !5 mintes');
+        }
+
+        return $result;
     }
 }

--- a/src/Extensions/Image/TwitterRenderer.php
+++ b/src/Extensions/Image/TwitterRenderer.php
@@ -36,7 +36,7 @@ final class TwitterRenderer
         // cached forever. We'll cache the result for 5 minutes.
         if ($result === false) {
             Cache::forget(md5($url));
-            return Cache::remember(md5($url), now()->addSeconds(15), fn () => 'cached !5 mintes');
+            return Cache::remember(md5($url), now()->addSeconds(15), fn () => '');
         }
 
         return $result;

--- a/src/Extensions/Image/TwitterRenderer.php
+++ b/src/Extensions/Image/TwitterRenderer.php
@@ -36,6 +36,7 @@ final class TwitterRenderer
         // cached forever. We'll cache the result for 5 minutes.
         if ($result === false) {
             Cache::forget(md5($url));
+
             return Cache::remember(md5($url), now()->addMinutes(5), fn () => '');
         }
 

--- a/tests/Extensions/Image/TwitterRendererTest.php
+++ b/tests/Extensions/Image/TwitterRendererTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Cache;
+use ARKEcosystem\CommonMark\Extensions\Image\MediaUrl;
+use ARKEcosystem\CommonMark\Extensions\Image\TwitterRenderer;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Carbon;
+
+it('should render twitter embeds', function () {
+    $response = [
+        "url" => "https://twitter.com/arkecosystem/status/1234",
+        "html" => "<blockquote>...</blockquote>",
+    ];
+  
+    Http::fake([
+        'publish.twitter.com/*' => $response,
+    ]);
+    
+    $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
+    $subject = new TwitterRenderer();
+    
+    expect($subject->render($mediaUrl))->toBe('<blockquote>...</blockquote>');
+});
+
+it('gets the response from the cache if set', function () {
+    $id = 'arkecosystem/status/1234';
+    Cache::set(md5('https://twitter.com/' . $id), '<blockquote>cached</blockquote>');
+    
+    $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
+    $subject = new TwitterRenderer();
+    
+    expect($subject->render($mediaUrl))->toBe('<blockquote>cached</blockquote>');
+});
+
+
+it('returns an empty string if receives an invalid response', function () {
+  $response = [
+      "invalid" => 'invalid',
+  ];
+
+  Http::fake([
+      'publish.twitter.com/*' => $response,
+  ]);
+  
+  $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
+  
+  $subject = new TwitterRenderer();
+  
+  expect($subject->render($mediaUrl))->toBe('');
+});
+
+it('returns an empty string if twitter server is down', function () {
+  Http::fake([
+      'publish.twitter.com/*' => function () {
+        throw new ConnectionException;
+      },
+  ]);
+  
+  $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
+  
+  $subject = new TwitterRenderer();
+  
+  expect($subject->render($mediaUrl))->toBe('');
+});
+
+it('caches the response for 5 minutes if server is down', function () {
+  $id = 'arkecosystem/status/1234';
+  $cacheKey = md5('https://twitter.com/' . $id);
+
+  Cache::shouldReceive('rememberForever')
+    ->once()
+    ->with($cacheKey, \Closure::class)
+    ->andReturn(false)
+    ->shouldReceive('forget')
+    ->once()
+    ->with($cacheKey)
+    ->shouldReceive('remember')
+    ->with($cacheKey, Carbon::class, \Closure::class)
+    ->once()
+    ->andReturn('');
+  
+  Http::fake([
+      'publish.twitter.com/*' => function () {
+          throw new ConnectionException;
+      },
+  ]);
+  
+  $mediaUrl = new MediaUrl('twitter', $id);
+  
+  $subject = new TwitterRenderer();
+  
+  expect($subject->render($mediaUrl))->toBe('');
+});

--- a/tests/Extensions/Image/TwitterRendererTest.php
+++ b/tests/Extensions/Image/TwitterRendererTest.php
@@ -1,74 +1,73 @@
 <?php
 
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Cache;
 use ARKEcosystem\CommonMark\Extensions\Image\MediaUrl;
 use ARKEcosystem\CommonMark\Extensions\Image\TwitterRenderer;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 
 it('should render twitter embeds', function () {
     $response = [
-        "url" => "https://twitter.com/arkecosystem/status/1234",
-        "html" => "<blockquote>...</blockquote>",
+        'url'  => 'https://twitter.com/arkecosystem/status/1234',
+        'html' => '<blockquote>...</blockquote>',
     ];
-  
+
     Http::fake([
         'publish.twitter.com/*' => $response,
     ]);
-    
+
     $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
     $subject = new TwitterRenderer();
-    
+
     expect($subject->render($mediaUrl))->toBe('<blockquote>...</blockquote>');
 });
 
 it('gets the response from the cache if set', function () {
     $id = 'arkecosystem/status/1234';
-    Cache::set(md5('https://twitter.com/' . $id), '<blockquote>cached</blockquote>');
-    
+    Cache::set(md5('https://twitter.com/'.$id), '<blockquote>cached</blockquote>');
+
     $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
     $subject = new TwitterRenderer();
-    
+
     expect($subject->render($mediaUrl))->toBe('<blockquote>cached</blockquote>');
 });
 
-
 it('returns an empty string if receives an invalid response', function () {
-  $response = [
-      "invalid" => 'invalid',
+    $response = [
+      'invalid' => 'invalid',
   ];
 
-  Http::fake([
+    Http::fake([
       'publish.twitter.com/*' => $response,
   ]);
-  
-  $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
-  
-  $subject = new TwitterRenderer();
-  
-  expect($subject->render($mediaUrl))->toBe('');
+
+    $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
+
+    $subject = new TwitterRenderer();
+
+    expect($subject->render($mediaUrl))->toBe('');
 });
 
 it('returns an empty string if twitter server is down', function () {
-  Http::fake([
+    Http::fake([
       'publish.twitter.com/*' => function () {
-        throw new ConnectionException;
+          throw new ConnectionException();
       },
   ]);
-  
-  $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
-  
-  $subject = new TwitterRenderer();
-  
-  expect($subject->render($mediaUrl))->toBe('');
+
+    $mediaUrl = new MediaUrl('twitter', 'arkecosystem/status/1234');
+
+    $subject = new TwitterRenderer();
+
+    expect($subject->render($mediaUrl))->toBe('');
 });
 
 it('caches the response for 5 minutes if server is down', function () {
-  $id = 'arkecosystem/status/1234';
-  $cacheKey = md5('https://twitter.com/' . $id);
+    $id = 'arkecosystem/status/1234';
+    $cacheKey = md5('https://twitter.com/'.$id);
 
-  Cache::shouldReceive('rememberForever')
+    Cache::shouldReceive('rememberForever')
     ->once()
     ->with($cacheKey, \Closure::class)
     ->andReturn(false)
@@ -79,16 +78,16 @@ it('caches the response for 5 minutes if server is down', function () {
     ->with($cacheKey, Carbon::class, \Closure::class)
     ->once()
     ->andReturn('');
-  
-  Http::fake([
+
+    Http::fake([
       'publish.twitter.com/*' => function () {
-          throw new ConnectionException;
+          throw new ConnectionException();
       },
   ]);
-  
-  $mediaUrl = new MediaUrl('twitter', $id);
-  
-  $subject = new TwitterRenderer();
-  
-  expect($subject->render($mediaUrl))->toBe('');
+
+    $mediaUrl = new MediaUrl('twitter', $id);
+
+    $subject = new TwitterRenderer();
+
+    expect($subject->render($mediaUrl))->toBe('');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The ticket only mentions the case where the URL is invalid but is theoretically possible that Twitter server is down, is that is the case we will also have an exception.

1. Validates the response of the Twitter API and returns an empty string if no valid result.
2. If receives a connection exception will also return an empty string but in this case the cache will be only for 5 minutes so it can try again later.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
